### PR TITLE
hardware: add support for new hardware variants

### DIFF
--- a/digi/xbee/models/hw.py
+++ b/digi/xbee/models/hw.py
@@ -85,6 +85,7 @@ class HardwareVersion(Enum):
     XBEE3_SMT = (0x42, "XBEE3 SMT")
     XBEE3_TH = (0x43, "XBEE3 TH")
     CELLULAR_3G = (0x44, "XBee Cellular 3G")
+    XB8X = (0x45, "XB8X")
     CELLULAR_LTE_VERIZON = (0x46, "XBee Cellular LTE-M Verizon")
     CELLULAR_LTE_ATT = (0x47, "XBee Cellular LTE-M AT&T")
     CELLULAR_NBIOT_EUROPE = (0x48, "XBee Cellular NBIoT Europe")

--- a/digi/xbee/models/protocol.py
+++ b/digi/xbee/models/protocol.py
@@ -241,10 +241,13 @@ class XBeeProtocol(Enum):
         elif hardware_version == HardwareVersion.CELLULAR_NBIOT_EUROPE.code:
             return XBeeProtocol.CELLULAR_NBIOT
 
-        elif hardware_version in [HardwareVersion.XBEE3,
-                                  HardwareVersion.XBEE3_SMT,
-                                  HardwareVersion.XBEE3_TH]:
+        elif hardware_version in [HardwareVersion.XBEE3.code,
+                                  HardwareVersion.XBEE3_SMT.code,
+                                  HardwareVersion.XBEE3_TH.code]:
             return XBeeProtocol.ZIGBEE
+
+        elif hardware_version == HardwareVersion.XB8X.code:
+            return XBeeProtocol.DIGI_MESH
 
         return XBeeProtocol.ZIGBEE
 


### PR DESCRIPTION
- 0x45 - XB8X

- Fixed a bug in the protocol assignation algorithm with XBee3 variants.

Signed-off-by: Diego Escalona <diego.escalona@digi.com>