### PR TITLE
Fix timeouts on Unix platform

### DIFF
--- a/digi/xbee/devices.py
+++ b/digi/xbee/devices.py
@@ -2528,11 +2528,11 @@ class XBeeDevice(AbstractXBeeDevice):
             remote = RemoteXBeeDevice(self, x64addr, x16addr)
 
         if explicit:
-            msg = ExplicitXBeeMessage(packet.rf_data, remote, time.clock(), packet.source_endpoint,
+            msg = ExplicitXBeeMessage(packet.rf_data, remote, time.time(), packet.source_endpoint,
                                       packet.dest_endpoint, packet.cluster_id,
                                       packet.profile_id, packet.is_broadcast())
         else:
-            msg = XBeeMessage(packet.rf_data, remote, time.clock(), packet.is_broadcast())
+            msg = XBeeMessage(packet.rf_data, remote, time.time(), packet.is_broadcast())
 
         return msg
 
@@ -4312,8 +4312,8 @@ class WiFiDevice(IPDevice):
         try:
             self.send_packet(ATCommPacket(self.get_next_frame_id(), "AS"), False)
 
-            dead_line = time.clock() + self.__DISCOVER_TIMEOUT
-            while self.__scanning_aps and time.clock() < dead_line:
+            dead_line = time.time() + self.__DISCOVER_TIMEOUT
+            while self.__scanning_aps and time.time() < dead_line:
                 time.sleep(0.1)
 
             # Check if we exited because of a timeout.
@@ -4376,8 +4376,8 @@ class WiFiDevice(IPDevice):
             self.set_parameter("PK", bytearray(password, "utf8"))
 
         # Wait for the module to connect to the access point.
-        dead_line = time.clock() + self.__ap_timeout
-        while time.clock() < dead_line:
+        dead_line = time.time() + self.__ap_timeout
+        while time.time() < dead_line:
             time.sleep(0.1)
             # Get the association indication value of the module.
             status = self.get_parameter("AI")
@@ -4459,8 +4459,8 @@ class WiFiDevice(IPDevice):
            | :meth:`.WiFiDevice.set_access_point_timeout`
         """
         self.execute_command("NR")
-        dead_line = time.clock() + self.__ap_timeout
-        while time.clock() < dead_line:
+        dead_line = time.time() + self.__ap_timeout
+        while time.time() < dead_line:
             time.sleep(0.1)
             # Get the association indication value of the module.
             status = self.get_parameter("AI")
@@ -5686,7 +5686,7 @@ class XBeeNetwork(object):
             node_id (String, optional): node identifier of the remote XBee device to discover. Optional.
         """
         try:
-            init_time = time.clock()
+            init_time = time.time()
 
             # In 802.15.4 devices, the discovery finishes when the 'end' command 
             # is received, so it's not necessary to calculate the timeout.
@@ -5704,7 +5704,7 @@ class XBeeNetwork(object):
             if not is_802_compatible:
                 # If XBee device is not 802.15.4, wait until timeout expires.
                 while self.__discovering or self.__sought_device_id is not None:
-                    if (time.clock() - init_time) > timeout:
+                    if (time.time() - init_time) > timeout:
                         with self.__lock:
                             self.__discovering = False
                         break

--- a/digi/xbee/models/message.py
+++ b/digi/xbee/models/message.py
@@ -66,11 +66,11 @@ class XBeeMessage(object):
 
     def __get_timestamp(self):
         """
-        Returns the moment when the message was received as a ``time.clock()``
+        Returns the moment when the message was received as a ``time.time()``
         function returned value.
 
         Returns:
-            Float: the returned value of using :meth:`time.clock()` function when the message was received.
+            Float: the returned value of using :meth:`time.time()` function when the message was received.
         """
         return self.__timestamp
 

--- a/digi/xbee/reader.py
+++ b/digi/xbee/reader.py
@@ -561,7 +561,7 @@ class PacketListener(threading.Thread):
                 xbee_packet.get_frame_type() == ApiFrameType.RECEIVE_PACKET):
             _data = xbee_packet.rf_data
             is_broadcast = xbee_packet.receive_options == ReceiveOptions.BROADCAST_PACKET
-            self.__data_received(XBeeMessage(_data, remote, time.clock(), is_broadcast))
+            self.__data_received(XBeeMessage(_data, remote, time.time(), is_broadcast))
             self._log.info(self._LOG_PATTERN.format(port=self.__xbee_device.serial_port.port,
                                                     event="RECEIVED",
                                                     fr_type="DATA",
@@ -583,7 +583,7 @@ class PacketListener(threading.Thread):
         elif (xbee_packet.get_frame_type() == ApiFrameType.RX_IO_16 or
               xbee_packet.get_frame_type() == ApiFrameType.RX_IO_64 or
               xbee_packet.get_frame_type() == ApiFrameType.IO_DATA_SAMPLE_RX_INDICATOR):
-            self.__io_sample_received(xbee_packet.io_sample, remote, time.clock())
+            self.__io_sample_received(xbee_packet.io_sample, remote, time.time())
             self._log.info(self._LOG_PATTERN.format(port=self.__xbee_device.serial_port.port,
                                                     event="RECEIVED",
                                                     fr_type="IOSAMPLE",
@@ -596,7 +596,7 @@ class PacketListener(threading.Thread):
             is_broadcast = False
             # If it's 'special' packet, notify the data_received callbacks too:
             if self.__is_special_explicit_packet(xbee_packet):
-                self.__data_received(XBeeMessage(xbee_packet.rf_data, remote, time.clock(), is_broadcast))
+                self.__data_received(XBeeMessage(xbee_packet.rf_data, remote, time.time(), is_broadcast))
             self.__explicit_packet_received(PacketListener.__expl_to_message(remote, is_broadcast, xbee_packet))
             self._log.info(self._LOG_PATTERN.format(port=self.__xbee_device.serial_port.port,
                                                     event="RECEIVED",
@@ -816,7 +816,7 @@ class PacketListener(threading.Thread):
         Returns:
             :class:`.ExplicitXBeeMessage`: the explicit message generated from the provided parameters.
         """
-        return ExplicitXBeeMessage(xbee_packet.rf_data, remote, time.clock(), xbee_packet.source_endpoint,
+        return ExplicitXBeeMessage(xbee_packet.rf_data, remote, time.time(), xbee_packet.source_endpoint,
                                    xbee_packet.dest_endpoint, xbee_packet.cluster_id,
                                    xbee_packet.profile_id, broadcast)
 
@@ -899,8 +899,8 @@ class XBeeQueue(Queue):
             return None
         else:
             xbee_packet = self.get_by_remote(remote_xbee_device, None)
-            dead_line = time.clock() + timeout
-            while xbee_packet is None and dead_line > time.clock():
+            dead_line = time.time() + timeout
+            while xbee_packet is None and dead_line > time.time():
                 time.sleep(0.1)
                 xbee_packet = self.get_by_remote(remote_xbee_device, None)
             if xbee_packet is None:
@@ -937,8 +937,8 @@ class XBeeQueue(Queue):
             return None
         else:
             xbee_packet = self.get_by_ip(ip_addr, None)
-            dead_line = time.clock() + timeout
-            while xbee_packet is None and dead_line > time.clock():
+            dead_line = time.time() + timeout
+            while xbee_packet is None and dead_line > time.time():
                 time.sleep(0.1)
                 xbee_packet = self.get_by_ip(ip_addr, None)
             if xbee_packet is None:

--- a/doc/user_doc/handling_analog_and_digital_io_lines.rst
+++ b/doc/user_doc/handling_analog_and_digital_io_lines.rst
@@ -599,8 +599,8 @@ event is raised:
 * The received IO sample as an ``IOSample`` object.
 * The remote XBee device that sent the IO sample as a ``RemoteXBeeDevice``
   object.
-* The time in which the IO sample was received as an ``Integer`` (calculated
-  with Python standard ``time.clock()``).
+* The time in which the IO sample was received as an ``Float`` (calculated
+  with Python standard ``time.time()``).
 
 To stop receiving notifications of new IO samples, remove the added callback
 using the ``del_io_sample_received_callback()`` method.

--- a/functional_tests/long_test.py
+++ b/functional_tests/long_test.py
@@ -88,9 +88,9 @@ def main(argv):
 
         print("Sending data...\n")
 
-        dead_line = time.clock() + duration
+        dead_line = time.time() + duration
 
-        while dead_line > time.clock():
+        while dead_line > time.time():
             retries = MAX_RETRIES
             data_received = False
             while not data_received:


### PR DESCRIPTION
Replaces all `time.clock()` calls with `time.time()`. On the the Unix platform `time.clock()` is not wall-time like it is on Windows. It results in timeouts that last orders of magnitude longer than expected on the Ubunutu 16.04 system I am working on. For instance this code was talking over an hour to finish:

```
xbee = ZigBeeDevice("/dev/ttyUSB0", 9600)
xbee.open()

xnet = xbee.get_network()
xnet.set_discovery_timeout(3.2)

xnet.start_discovery_process()
while xnet.is_discovery_running():
    time.sleep(0.5)

# >>> would take over an hour or more to get here

for device in xnet.get_devices():
    print(device)

print('done')
```

Also `time.clock()` is depreciated. 

My PR is very untested beyond the code I provided above as I have just begun using the lib.  So more testing is needed.