### PR TITLE
operating_mode: fix packet reader function to correctly escape the bytes

### DIFF
--- a/digi/xbee/packets/base.py
+++ b/digi/xbee/packets/base.py
@@ -229,7 +229,7 @@ class XBeePacket:
         return esc_data
 
     @staticmethod
-    def _unescape_data(data):
+    def unescape_data(data):
         """
         Un-escapes the provided bytearray data.
 
@@ -482,15 +482,13 @@ class GenericXBeePacket(XBeeAPIPacket):
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
             raise InvalidOperatingModeException(operating_mode + " is not supported.")
 
-        unesc_raw = XBeeAPIPacket._unescape_data(raw) if operating_mode == OperatingMode.ESCAPED_API_MODE else raw
+        XBeeAPIPacket._check_api_packet(raw, min_length=GenericXBeePacket.__MIN_PACKET_LENGTH)
 
-        XBeeAPIPacket._check_api_packet(unesc_raw, min_length=GenericXBeePacket.__MIN_PACKET_LENGTH)
-
-        if unesc_raw[3] != ApiFrameType.GENERIC.code:
+        if raw[3] != ApiFrameType.GENERIC.code:
             raise InvalidPacketException("Wrong frame type, expected: " + ApiFrameType.GENERIC.description +
                                          ". Value: " + ApiFrameType.GENERIC.code)
 
-        return GenericXBeePacket(unesc_raw[4:-1])
+        return GenericXBeePacket(raw[4:-1])
 
     def _get_api_packet_spec_data(self):
         """

--- a/digi/xbee/packets/cellular.py
+++ b/digi/xbee/packets/cellular.py
@@ -83,13 +83,12 @@ class RXSMSPacket(XBeeAPIPacket):
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
         
-        _raw = XBeeAPIPacket._unescape_data(raw) if operating_mode == OperatingMode.ESCAPED_API_MODE else raw
-        
-        XBeeAPIPacket._check_api_packet(_raw, min_length=RXSMSPacket.__MIN_PACKET_LENGTH)
-        if _raw[3] != ApiFrameType.RX_SMS.code:
+        XBeeAPIPacket._check_api_packet(raw, min_length=RXSMSPacket.__MIN_PACKET_LENGTH)
+
+        if raw[3] != ApiFrameType.RX_SMS.code:
             raise InvalidPacketException("This packet is not an RXSMSPacket")
 
-        return RXSMSPacket(_raw[4:23].decode("utf8").replace("\0", ""), _raw[24:-1].decode("utf8"))
+        return RXSMSPacket(raw[4:23].decode("utf8").replace("\0", ""), raw[24:-1].decode("utf8"))
 
     def needs_id(self):
         """
@@ -252,13 +251,12 @@ class TXSMSPacket(XBeeAPIPacket):
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
         
-        _raw = XBeeAPIPacket._unescape_data(raw) if operating_mode == OperatingMode.ESCAPED_API_MODE else raw
-        
         XBeeAPIPacket._check_api_packet(raw, min_length=TXSMSPacket.__MIN_PACKET_LENGTH)
-        if _raw[3] != ApiFrameType.TX_SMS.code:
+
+        if raw[3] != ApiFrameType.TX_SMS.code:
             raise InvalidPacketException("This packet is not a TXSMSPacket")
 
-        return TXSMSPacket(_raw[4], _raw[6:25].decode("utf8").replace("\0", ""), _raw[26:-1].decode("utf8"))
+        return TXSMSPacket(raw[4], raw[6:25].decode("utf8").replace("\0", ""), raw[26:-1].decode("utf8"))
 
     def needs_id(self):
         """

--- a/digi/xbee/packets/common.py
+++ b/digi/xbee/packets/common.py
@@ -91,7 +91,6 @@ class ATCommPacket(XBeeAPIPacket):
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
 
-        raw = XBeeAPIPacket._unescape_data(raw) if operating_mode == OperatingMode.ESCAPED_API_MODE else raw
         XBeeAPIPacket._check_api_packet(raw, min_length=ATCommPacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.AT_COMMAND.code:
@@ -252,8 +251,6 @@ class ATCommResponsePacket(XBeeAPIPacket):
         """
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
-
-        raw = XBeeAPIPacket._unescape_data(raw) if operating_mode == OperatingMode.ESCAPED_API_MODE else raw
 
         XBeeAPIPacket._check_api_packet(raw, min_length=ATCommResponsePacket.__MIN_PACKET_LENGTH)
 
@@ -440,8 +437,6 @@ class ReceivePacket(XBeeAPIPacket):
         """
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
-
-        raw = XBeeAPIPacket._unescape_data(raw) if operating_mode == OperatingMode.ESCAPED_API_MODE else raw
 
         XBeeAPIPacket._check_api_packet(raw, min_length=ReceivePacket.__MIN_PACKET_LENGTH)
 
@@ -677,8 +672,6 @@ class RemoteATCommandPacket(XBeeAPIPacket):
         """
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
-
-        raw = XBeeAPIPacket._unescape_data(raw) if operating_mode == OperatingMode.ESCAPED_API_MODE else raw
 
         XBeeAPIPacket._check_api_packet(raw, min_length=RemoteATCommandPacket.__MIN_PACKET_LENGTH)
 
@@ -936,8 +929,6 @@ class RemoteATCommandResponsePacket(XBeeAPIPacket):
         """
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
-
-        raw = XBeeAPIPacket._unescape_data(raw) if operating_mode == OperatingMode.ESCAPED_API_MODE else raw
 
         XBeeAPIPacket._check_api_packet(raw, min_length=RemoteATCommandResponsePacket.__MIN_PACKET_LENGTH)
 
@@ -1211,8 +1202,6 @@ class TransmitPacket(XBeeAPIPacket):
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
 
-        raw = XBeeAPIPacket._unescape_data(raw) if operating_mode == OperatingMode.ESCAPED_API_MODE else raw
-
         XBeeAPIPacket._check_api_packet(raw, min_length=TransmitPacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.TRANSMIT_REQUEST.code:
@@ -1463,8 +1452,6 @@ class TransmitStatusPacket(XBeeAPIPacket):
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
 
-        raw = XBeeAPIPacket._unescape_data(raw) if operating_mode == OperatingMode.ESCAPED_API_MODE else raw
-
         XBeeAPIPacket._check_api_packet(raw, min_length=TransmitStatusPacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.TRANSMIT_STATUS.code:
@@ -1663,8 +1650,6 @@ class ModemStatusPacket(XBeeAPIPacket):
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
 
-        raw = XBeeAPIPacket._unescape_data(raw) if operating_mode == OperatingMode.ESCAPED_API_MODE else raw
-
         XBeeAPIPacket._check_api_packet(raw, min_length=ModemStatusPacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.MODEM_STATUS.code:
@@ -1798,8 +1783,6 @@ class IODataSampleRxIndicatorPacket(XBeeAPIPacket):
         """
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
-
-        raw = XBeeAPIPacket._unescape_data(raw) if operating_mode == OperatingMode.ESCAPED_API_MODE else raw
 
         XBeeAPIPacket._check_api_packet(raw, min_length=IODataSampleRxIndicatorPacket.__MIN_PACKET_LENGTH)
 
@@ -2150,7 +2133,6 @@ class ExplicitAddressingPacket(XBeeAPIPacket):
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
 
-        raw = XBeeAPIPacket._unescape_data(raw) if operating_mode == OperatingMode.ESCAPED_API_MODE else raw
         XBeeAPIPacket._check_api_packet(raw, min_length=ExplicitAddressingPacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.EXPLICIT_ADDRESSING.code:
@@ -2511,7 +2493,6 @@ class ExplicitRXIndicatorPacket(XBeeAPIPacket):
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
 
-        raw = XBeeAPIPacket._unescape_data(raw) if operating_mode == OperatingMode.ESCAPED_API_MODE else raw
         XBeeAPIPacket._check_api_packet(raw, min_length=ExplicitRXIndicatorPacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.EXPLICIT_RX_INDICATOR.code:

--- a/digi/xbee/packets/devicecloud.py
+++ b/digi/xbee/packets/devicecloud.py
@@ -90,7 +90,6 @@ class DeviceRequestPacket(XBeeAPIPacket):
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
 
-        raw = XBeeAPIPacket._unescape_data(raw) if operating_mode == OperatingMode.ESCAPED_API_MODE else raw
         XBeeAPIPacket._check_api_packet(raw, min_length=DeviceRequestPacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.DEVICE_REQUEST.code:
@@ -312,7 +311,6 @@ class DeviceResponsePacket(XBeeAPIPacket):
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
 
-        raw = XBeeAPIPacket._unescape_data(raw) if operating_mode == OperatingMode.ESCAPED_API_MODE else raw
         XBeeAPIPacket._check_api_packet(raw, min_length=DeviceResponsePacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.DEVICE_RESPONSE.code:
@@ -469,7 +467,6 @@ class DeviceResponseStatusPacket(XBeeAPIPacket):
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
 
-        raw = XBeeAPIPacket._unescape_data(raw) if operating_mode == OperatingMode.ESCAPED_API_MODE else raw
         XBeeAPIPacket._check_api_packet(raw, min_length=DeviceResponseStatusPacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.DEVICE_RESPONSE_STATUS.code:
@@ -585,7 +582,6 @@ class FrameErrorPacket(XBeeAPIPacket):
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
 
-        raw = XBeeAPIPacket._unescape_data(raw) if operating_mode == OperatingMode.ESCAPED_API_MODE else raw
         XBeeAPIPacket._check_api_packet(raw, min_length=FrameErrorPacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.FRAME_ERROR.code:
@@ -719,7 +715,6 @@ class SendDataRequestPacket(XBeeAPIPacket):
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
 
-        raw = XBeeAPIPacket._unescape_data(raw) if operating_mode == OperatingMode.ESCAPED_API_MODE else raw
         XBeeAPIPacket._check_api_packet(raw, min_length=SendDataRequestPacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.SEND_DATA_REQUEST.code:
@@ -939,7 +934,6 @@ class SendDataResponsePacket(XBeeAPIPacket):
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
 
-        raw = XBeeAPIPacket._unescape_data(raw) if operating_mode == OperatingMode.ESCAPED_API_MODE else raw
         XBeeAPIPacket._check_api_packet(raw, min_length=SendDataResponsePacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.SEND_DATA_RESPONSE.code:

--- a/digi/xbee/packets/network.py
+++ b/digi/xbee/packets/network.py
@@ -89,16 +89,14 @@ class RXIPv4Packet(XBeeAPIPacket):
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
 
-        _raw = XBeeAPIPacket._unescape_data(raw) if operating_mode == OperatingMode.ESCAPED_API_MODE else raw
+        XBeeAPIPacket._check_api_packet(raw, min_length=RXIPv4Packet.__MIN_PACKET_LENGTH)
 
-        XBeeAPIPacket._check_api_packet(_raw, min_length=RXIPv4Packet.__MIN_PACKET_LENGTH)
-
-        if _raw[3] != ApiFrameType.RX_IPV4.code:
+        if raw[3] != ApiFrameType.RX_IPV4.code:
             raise InvalidPacketException("This packet is not an RXIPv4Packet.")
 
-        return RXIPv4Packet(IPv4Address(bytes(_raw[4:8])), utils.bytes_to_int(_raw[8:10]),
-                            utils.bytes_to_int(_raw[10:12]), IPProtocol.get(_raw[12]),
-                            _raw[14:-1])
+        return RXIPv4Packet(IPv4Address(bytes(raw[4:8])), utils.bytes_to_int(raw[8:10]),
+                            utils.bytes_to_int(raw[10:12]), IPProtocol.get(raw[12]),
+                            raw[14:-1])
 
     def needs_id(self):
         """
@@ -341,8 +339,6 @@ class TXIPv4Packet(XBeeAPIPacket):
         """
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
-
-        raw = XBeeAPIPacket._unescape_data(raw) if operating_mode == OperatingMode.ESCAPED_API_MODE else raw
 
         XBeeAPIPacket._check_api_packet(raw, min_length=TXIPv4Packet.__MIN_PACKET_LENGTH)
 

--- a/digi/xbee/packets/raw.py
+++ b/digi/xbee/packets/raw.py
@@ -88,9 +88,8 @@ class TX64Packet(XBeeAPIPacket):
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
 
-        raw = XBeeAPIPacket._unescape_data(raw) if operating_mode == OperatingMode.ESCAPED_API_MODE else raw
-
         XBeeAPIPacket._check_api_packet(raw, min_length=TX64Packet.__MIN_PACKET_LENGTH)
+
         if raw[3] != ApiFrameType.TX_64.code:
             raise InvalidPacketException("This packet is not a TX 64 packet.")
 
@@ -276,9 +275,8 @@ class TX16Packet(XBeeAPIPacket):
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
 
-        raw = XBeeAPIPacket._unescape_data(raw) if operating_mode == OperatingMode.ESCAPED_API_MODE else raw
-
         XBeeAPIPacket._check_api_packet(raw, min_length=TX16Packet.__MIN_PACKET_LENGTH)
+
         if raw[3] != ApiFrameType.TX_16.code:
             raise InvalidPacketException("This packet is not a TX 16 packet.")
 
@@ -462,9 +460,8 @@ class TXStatusPacket(XBeeAPIPacket):
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
 
-        raw = XBeeAPIPacket._unescape_data(raw) if operating_mode == OperatingMode.ESCAPED_API_MODE else raw
-
         XBeeAPIPacket._check_api_packet(raw, min_length=TXStatusPacket.__MIN_PACKET_LENGTH)
+
         if raw[3] != ApiFrameType.TX_STATUS.code:
             raise InvalidPacketException("This packet is not a TX status packet.")
 
@@ -591,9 +588,8 @@ class RX64Packet(XBeeAPIPacket):
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
 
-        raw = XBeeAPIPacket._unescape_data(raw) if operating_mode == OperatingMode.ESCAPED_API_MODE else raw
-
         XBeeAPIPacket._check_api_packet(raw, min_length=RX64Packet.__MIN_PACKET_LENGTH)
+
         if raw[3] != ApiFrameType.RX_64.code:
             raise InvalidPacketException("This packet is not an RX 64 packet.")
 
@@ -802,9 +798,8 @@ class RX16Packet(XBeeAPIPacket):
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
 
-        raw = XBeeAPIPacket._unescape_data(raw) if operating_mode == OperatingMode.ESCAPED_API_MODE else raw
-
         XBeeAPIPacket._check_api_packet(raw, min_length=RX16Packet.__MIN_PACKET_LENGTH)
+
         if raw[3] != ApiFrameType.RX_16.code:
             raise InvalidPacketException("This packet is not an RX 16 Packet")
 
@@ -1008,9 +1003,8 @@ class RX64IOPacket(XBeeAPIPacket):
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
 
-        raw = XBeeAPIPacket._unescape_data(raw) if operating_mode == OperatingMode.ESCAPED_API_MODE else raw
-
         XBeeAPIPacket._check_api_packet(raw, min_length=RX64IOPacket.__MIN_PACKET_LENGTH)
+
         if raw[3] != ApiFrameType.RX_IO_64.code:
             raise InvalidPacketException("This packet is not an RX 64 IO packet.")
 
@@ -1272,9 +1266,8 @@ class RX16IOPacket(XBeeAPIPacket):
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
 
-        raw = XBeeAPIPacket._unescape_data(raw) if operating_mode == OperatingMode.ESCAPED_API_MODE else raw
-
         XBeeAPIPacket._check_api_packet(raw, min_length=RX16IOPacket.__MIN_PACKET_LENGTH)
+
         if raw[3] != ApiFrameType.RX_IO_16.code:
             raise InvalidPacketException("This packet is not an RX 16 IO packet.")
 

--- a/digi/xbee/packets/wifi.py
+++ b/digi/xbee/packets/wifi.py
@@ -93,8 +93,6 @@ class IODataSampleRxIndicatorWifiPacket(XBeeAPIPacket):
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
 
-        raw = XBeeAPIPacket._unescape_data(raw) if operating_mode == OperatingMode.ESCAPED_API_MODE else raw
-
         XBeeAPIPacket._check_api_packet(raw, min_length=IODataSampleRxIndicatorWifiPacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.IO_DATA_SAMPLE_RX_INDICATOR_WIFI.code:
@@ -378,8 +376,6 @@ class RemoteATCommandWifiPacket(XBeeAPIPacket):
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
 
-        raw = XBeeAPIPacket._unescape_data(raw) if operating_mode == OperatingMode.ESCAPED_API_MODE else raw
-
         XBeeAPIPacket._check_api_packet(raw, min_length=RemoteATCommandWifiPacket.__MIN_PACKET_LENGTH)
 
         if raw[3] != ApiFrameType.REMOTE_AT_COMMAND_REQUEST_WIFI.code:
@@ -606,8 +602,6 @@ class RemoteATCommandResponseWifiPacket(XBeeAPIPacket):
         """
         if operating_mode != OperatingMode.ESCAPED_API_MODE and operating_mode != OperatingMode.API_MODE:
             raise InvalidOperatingModeException(operating_mode.name + " is not supported.")
-
-        raw = XBeeAPIPacket._unescape_data(raw) if operating_mode == OperatingMode.ESCAPED_API_MODE else raw
 
         XBeeAPIPacket._check_api_packet(raw, min_length=RemoteATCommandResponseWifiPacket.__MIN_PACKET_LENGTH)
 

--- a/digi/xbee/reader.py
+++ b/digi/xbee/reader.py
@@ -27,7 +27,7 @@ from digi.xbee.models.options import ReceiveOptions
 from digi.xbee.models.protocol import XBeeProtocol
 from digi.xbee.packets import factory
 from digi.xbee.packets.aft import ApiFrameType
-from digi.xbee.packets.base import XBeePacket
+from digi.xbee.packets.base import XBeePacket, XBeeAPIPacket
 from digi.xbee.packets.common import ReceivePacket
 from digi.xbee.packets.raw import RX64Packet, RX16Packet
 from digi.xbee.util import utils
@@ -295,7 +295,7 @@ class PacketListener(threading.Thread):
         try:
             self.__stop = False
             while not self.__stop:
-                # Try to read a packet.
+                # Try to read a packet. Read packet is unescaped.
                 raw_packet = self.__try_read_packet(self.__xbee_device.operating_mode)
 
                 if raw_packet is not None:
@@ -625,18 +625,28 @@ class PacketListener(threading.Thread):
                                                     sender=str(xbee_packet.phone_number),
                                                     more_data=xbee_packet.data))
 
-    def __read_byte_into_packet(self, xbee_packet, operating_mode):
+    def __read_next_byte(self, operating_mode):
         """
-        Reads the next byte and appends it to ``xbee_packet``.
+        Returns the next byte in bytearray format. If the operating mode is
+        OperatingMode.ESCAPED_API_MODE, the bytearray could contain 2 bytes.
 
         If in escaped API mode and the byte that was read was the escape byte,
         it will also read the next byte.
+
+        Args:
+            operating_mode (:class:`.OperatingMode`): the operating mode in which the byte should be read.
+
+        Returns:
+            Bytearray: the read byte or bytes as bytearray, ``None`` otherwise.
         """
+        read_data = bytearray()
         read_byte = self.__serial_port.read_byte()
-        xbee_packet.append(read_byte)
+        read_data.append(read_byte)
         # Read escaped bytes in API escaped mode.
         if operating_mode == OperatingMode.ESCAPED_API_MODE and read_byte == XBeePacket.ESCAPE_BYTE:
-            xbee_packet.append(self.__serial_port.read_byte())
+            read_data.append(self.__serial_port.read_byte())
+
+        return read_data
 
     def __try_read_packet(self, operating_mode=OperatingMode.API_MODE):
         """
@@ -649,6 +659,9 @@ class PacketListener(threading.Thread):
         If the method can't read a complete and correct packet,
         it will return ``None``.
 
+        Args:
+            operating_mode (:class:`.OperatingMode`): the operating mode in which the packet should be read.
+
         Returns:
             Bytearray: the read packet as bytearray if a packet is read, ``None`` otherwise.
         """
@@ -658,14 +671,28 @@ class PacketListener(threading.Thread):
             xbee_packet[0] = self.__serial_port.read_byte()
             while xbee_packet[0] != SpecialByte.HEADER_BYTE.value:
                 xbee_packet[0] = self.__serial_port.read_byte()
-            packet_length = self.__serial_port.read_bytes(2)
+
             # Add packet length.
-            xbee_packet += packet_length
-            length = utils.length_to_int(packet_length)
-            # Add packet payload and checksum.
-            for _ in range(0, length + 1):
-                self.__read_byte_into_packet(xbee_packet, operating_mode)
-            return xbee_packet
+            packet_length_byte = bytearray()
+            for _ in range(0, 2):
+                packet_length_byte += self.__read_next_byte(operating_mode)
+            xbee_packet += packet_length_byte
+            # Length needs to be un-escaped to obtain its integer equivalent.
+            length = utils.length_to_int(XBeeAPIPacket.unescape_data(packet_length_byte))
+
+            # Add packet payload.
+            for _ in range(0, length):
+                xbee_packet += self.__read_next_byte(operating_mode)
+
+            # Add packet checksum.
+            for _ in range(0, 1):
+                xbee_packet += self.__read_next_byte(operating_mode)
+
+            # Return the packet unescaped.
+            if operating_mode == OperatingMode.ESCAPED_API_MODE:
+                return XBeeAPIPacket.unescape_data(xbee_packet)
+            else:
+                return xbee_packet
         except TimeoutException:
             return None
 
@@ -948,6 +975,44 @@ class XBeeQueue(Queue):
             while xbee_packet is None and dead_line > time.time():
                 time.sleep(0.1)
                 xbee_packet = self.get_by_ip(ip_addr, None)
+            if xbee_packet is None:
+                raise TimeoutException()
+            return xbee_packet
+
+    def get_by_id(self, frame_id, timeout=None):
+        """
+        Returns the first packet from the queue whose frame ID
+        matches the provided one.
+
+        If timeout is ``None``, this method is non-blocking. In this case, if there isn't
+        any received packet with the provided frame ID in the queue, it returns ``None``,
+        otherwise it returns an :class:`.XBeeAPIPacket`.
+
+        Args:
+            frame_id (Integer): The frame ID to look for in the list of packets.
+            timeout (Integer, optional): Timeout in seconds.
+
+        Returns:
+            :class:`.XBeeAPIPacket`: if there is any packet available before the timeout expires. If timeout is
+                ``None``, the returned value may be ``None``.
+
+        Raises:
+            TimeoutException: if timeout is not ``None`` and there isn't any packet available that matches
+            the provided frame ID before the timeout expires.
+        """
+        if timeout is None:
+            with self.mutex:
+                for xbee_packet in self.queue:
+                    if xbee_packet.needs_id() and xbee_packet.frame_id == frame_id:
+                        self.queue.remove(xbee_packet)
+                        return xbee_packet
+            return None
+        else:
+            xbee_packet = self.get_by_id(frame_id, None)
+            dead_line = time.time() + timeout
+            while xbee_packet is None and dead_line > time.time():
+                time.sleep(0.1)
+                xbee_packet = self.get_by_id(frame_id, None)
             if xbee_packet is None:
                 raise TimeoutException()
             return xbee_packet


### PR DESCRIPTION
- Transformed _unescape_data() method to public.
- Removed all unnecesary calls to unescape_data() from create_packet methods.
- Replaced __read_next_packet() method by a search in the xbee packet queue.

Signed-off-by: Héctor González <hector.gonzalez@digi.com>