### PR TITLE
fix #23: fix a problem when closing the device connection

### DIFF
--- a/digi/xbee/devices.py
+++ b/digi/xbee/devices.py
@@ -1278,8 +1278,6 @@ class XBeeDevice(AbstractXBeeDevice):
 
         if self._packet_listener is not None:
             self._packet_listener.stop()
-            # Wait 100 ms before closing the port.
-            time.sleep(0.1)
 
         if self._serial_port is not None and self._serial_port.isOpen():
             self._serial_port.close()

--- a/digi/xbee/reader.py
+++ b/digi/xbee/reader.py
@@ -324,10 +324,13 @@ class PacketListener(threading.Thread):
                     # Execute all user callbacks.
                     self.__execute_user_callbacks(read_packet, remote)
         except Exception as e:
-            self.__xbee_device.serial_port.close()
-            self._log.exception(e)
+            if not self.__stop:
+                self._log.exception(e)
         finally:
-            self.__stop = True
+            if not self.__stop:
+                self.__stop = True
+                if self.__serial_port.isOpen():
+                    self.__serial_port.close()
 
     def stop(self):
         """


### PR DESCRIPTION
The serial port is only closed in the XBee reader if the process has not
been stopped and the serial port is still open.

Signed-off-by: Ruben Moral <ruben.moral@digi.com>