### PR TITLE
fix #28: return an unknown XBee packet when the received packet is not supported by the library instead of raising an exception

### DIFF
--- a/digi/xbee/packets/aft.py
+++ b/digi/xbee/packets/aft.py
@@ -58,6 +58,7 @@ class ApiFrameType(Enum):
     DEVICE_RESPONSE_STATUS = (0xBA, "Device Response Status")
     FRAME_ERROR = (0xFE, "Frame Error")
     GENERIC = (0xFF, "Generic")
+    UNKNOWN = (-1, "Unknown Packet")
 
     def __init__(self, code, description):
         self.__code = code
@@ -90,13 +91,13 @@ class ApiFrameType(Enum):
             code (Integer): the code of the API frame type to get.
 
         Returns:
-            :class:`.ApiFrameType`: the API frame type associated to the given code or ``None`` if
+            :class:`.ApiFrameType`: the API frame type associated to the given code or ``UNKNOWN`` if
                 the given code is not a valid ApiFrameType code.
         """
         try:
             return cls.lookupTable[code]
         except KeyError:
-            return None
+            return ApiFrameType.UNKNOWN
 
     code = property(__get_code)
     """Integer. The API frame type code."""

--- a/digi/xbee/packets/factory.py
+++ b/digi/xbee/packets/factory.py
@@ -108,9 +108,6 @@ def build_frame(packet_bytearray, operating_mode=OperatingMode.API_MODE):
     Args:
         packet_bytearray (Bytearray): the raw data of the packet to build.
         operating_mode (:class:`.OperatingMode`): the operating mode in which the raw data has been captured.
-    
-    Raises:
-        NotImplementedError: if the packet defined by the bytearray is not supported.
 
     .. seealso::
        | :class:`.OperatingMode`
@@ -208,4 +205,4 @@ def build_frame(packet_bytearray, operating_mode=OperatingMode.API_MODE):
         return FrameErrorPacket.create_packet(packet_bytearray, operating_mode)
 
     else:
-        raise NotImplementedError("Frame type " + str(frame_type) + " is not supported.")
+        return UnknownXBeePacket.create_packet(packet_bytearray, operating_mode)


### PR DESCRIPTION

Signed-off-by: Ruben Moral <ruben.moral@digi.com>