### PR TITLE
Fix a leak in add_remote()

### DIFF
--- a/digi/xbee/devices.py
+++ b/digi/xbee/devices.py
@@ -135,6 +135,8 @@ class AbstractXBeeDevice(object):
             return False
         if self.get_64bit_addr() is not None and other.get_64bit_addr() is not None:
             return self.get_64bit_addr() == other.get_64bit_addr()
+        if self.get_16bit_addr() is not None and other.get_16bit_addr() is not None:
+            return self.get_16bit_addr() == other.get_16bit_addr()
         return False
 
     def update_device_data_from(self, device):


### PR DESCRIPTION
When a message received callback has been added, `add_remote()` is led to
believe that every xbee with only a 16bit addr and no 64bit addr is unique.
This leaks one RemoteXBeeDevice worth of memory each time a packet is
received.