### PR TITLE
fix #52: add AT Command Queue packet and use it when the apply changes flag is set to false

### DIFF
--- a/digi/xbee/packets/aft.py
+++ b/digi/xbee/packets/aft.py
@@ -30,6 +30,7 @@ class ApiFrameType(Enum):
     TX_16 = (0x01, "TX (Transmit) Request 16-bit address")
     REMOTE_AT_COMMAND_REQUEST_WIFI = (0x07, "Remote AT Command Request (Wi-Fi)")
     AT_COMMAND = (0x08, "AT Command")
+    AT_COMMAND_QUEUE = (0x09, "AT Command Queue")
     TRANSMIT_REQUEST = (0x10, "Transmit Request")
     EXPLICIT_ADDRESSING = (0x11, "Explicit Addressing Command Frame")
     REMOTE_AT_COMMAND_REQUEST = (0x17, "Remote AT Command Request")

--- a/digi/xbee/packets/factory.py
+++ b/digi/xbee/packets/factory.py
@@ -120,6 +120,9 @@ def build_frame(packet_bytearray, operating_mode=OperatingMode.API_MODE):
     elif frame_type == ApiFrameType.AT_COMMAND:
         return ATCommPacket.create_packet(packet_bytearray, operating_mode)
 
+    elif frame_type == ApiFrameType.AT_COMMAND_QUEUE:
+        return ATCommQueuePacket.create_packet(packet_bytearray, operating_mode)
+
     elif frame_type == ApiFrameType.AT_COMMAND_RESPONSE:
         return ATCommResponsePacket.create_packet(packet_bytearray, operating_mode)
 


### PR DESCRIPTION
Some code related to AT commands (get, set and execute) has been
re-organized and moved to the AbstractXBeeDevice class.

Signed-off-by: Ruben Moral <ruben.moral@digi.com>